### PR TITLE
Solved incorrent `margin-top` applied to desktop

### DIFF
--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -2,7 +2,7 @@
     <div class="fixed bg-dark-200 bg-doodles h-full w-full -z-10"></div>
     <div class="bg-dark-100 max-w-screen-lg mt mx-auto px-10 py-12 lg:my-48">
         <h1 class="text-4xl font-medium text-neutral-200 leading-snug">{{ $post->title }}</h1>
-        <div class="flex flex-col md:flex-row md:items-center mb-4 mt-3 md:space-x-3 space-y-2">
+        <div class="flex flex-col md:flex-row md:items-center mb-4 mt-3 md:space-x-3 md:space-y-2">
             @if($post->is_published)
                 <span class="text-sm text-neutral-300">Published at {{ $post->published_at->format('d M Y') }}</span>
             @else


### PR DESCRIPTION
There's a `margin-top` applied on all devices, it should only be showing at `md:` breakpoint.

Before:
![image](https://github.com/user-attachments/assets/ed82d3a5-0998-4d3f-bf3f-6928ef06e482)

After:
![image](https://github.com/user-attachments/assets/7fae6bf7-c2ce-4256-a692-f54be75346f4)
