### PR TITLE
Migrate from self-hosted workers to GitHub workers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,6 @@ jobs:
 
   deploy:
     needs: tests
-    runs-on: self-hosted
     environment: production
 
     steps:


### PR DESCRIPTION
Now that it's open source we can retire our self-hosted workers and use GitHub workers without affecting our billing hours. 🎉