### PR TITLE
Solved issue ordered list style

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -59,6 +59,17 @@
     unicode-bidi: isolate;
 }
 
+.markup li {
+    display: block;
+    list-style-type: decimal;
+    margin-block-start: 1em;
+    margin-block-end: 1em;
+    margin-inline-start: 0;
+    margin-inline-end: 0;
+    padding-inline-start: 40px;
+    unicode-bidi: isolate;
+}
+
 .markup blockquote {
     @apply border-l-4 border-ocean bg-ocean/15 p-4 my-4;
 }


### PR DESCRIPTION
Now ordered lists show decimal indicators.

Before:
![image](https://github.com/user-attachments/assets/0335abf9-603c-48a3-bcfc-efa5ed6b49ca)

After:
![image](https://github.com/user-attachments/assets/ddfec8f7-77a3-413a-be24-53d9a8182657)
